### PR TITLE
Fix admin filters and frontend category display issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![WordPress](https://img.shields.io/badge/WordPress-5.3%2B-blue.svg)
 ![PHP](https://img.shields.io/badge/PHP-7.2%2B-purple.svg)
-![Version](https://img.shields.io/badge/version-1.5.0-green.svg)
+![Version](https://img.shields.io/badge/version-1.5.1-green.svg)
 ![License](https://img.shields.io/badge/license-GPL--2.0-orange.svg)
 
 A powerful WordPress plugin providing advanced product and recipe archive functionality with AJAX filtering, SEO-friendly URLs, and hierarchical category management.

--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.5.0
+ * Version:           1.5.1
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -30,18 +30,14 @@ class Handy_Custom_Admin {
             return;
         }
 
-        // Get all product taxonomies
+        // Get priority product taxonomies for admin filtering
+        // Order reflects priority: market-segment, cooking-method, product-type, grade, size
         $taxonomies = array(
-            'product-category' => 'Category',
-            'grade' => 'Grade',
             'market-segment' => 'Market Segment',
             'product-cooking-method' => 'Cooking Method',
-            'product-menu-occasion' => 'Menu Occasion',
             'product-type' => 'Product Type',
-            'size' => 'Size',
-            'product-species' => 'Species',
-            'brand' => 'Brand',
-            'certification' => 'Certification'
+            'grade' => 'Grade',
+            'size' => 'Size'
         );
 
         foreach ($taxonomies as $taxonomy => $label) {
@@ -90,18 +86,13 @@ class Handy_Custom_Admin {
             return;
         }
 
-        // Get all product taxonomies
+        // Get priority product taxonomies for admin filtering
         $taxonomies = array(
-            'product-category',
-            'grade',
             'market-segment',
             'product-cooking-method',
-            'product-menu-occasion',
             'product-type',
-            'size',
-            'product-species',
-            'brand',
-            'certification'
+            'grade',
+            'size'
         );
 
         $tax_query = array();

--- a/includes/class-base-utils.php
+++ b/includes/class-base-utils.php
@@ -321,6 +321,23 @@ abstract class Handy_Custom_Base_Utils {
 	}
 
 	/**
+	 * Clear all caches on plugin version update
+	 * Handles cases where cache format changes between versions
+	 */
+	public static function clear_version_cache() {
+		$current_version = defined('Handy_Custom::VERSION') ? Handy_Custom::VERSION : '1.5.0';
+		$cached_version = get_option('handy_custom_cache_version', '');
+		
+		// If version changed, clear all caches
+		if ($cached_version !== $current_version) {
+			self::clear_term_cache();
+			self::clear_query_cache();
+			update_option('handy_custom_cache_version', $current_version);
+			Handy_Custom_Logger::log("Cache cleared due to version upgrade from {$cached_version} to {$current_version}", 'info');
+		}
+	}
+
+	/**
 	 * Initialize cache invalidation hooks
 	 * Should be called during plugin initialization
 	 */

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.5.0';
+	const VERSION = '1.5.1';
 
 	/**
 	 * Single instance of the class

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -59,6 +59,7 @@ class Handy_Custom {
 	private function load_includes() {
 		// Core functionality
 		require_once HANDY_CUSTOM_PLUGIN_DIR . 'includes/class-logger.php';
+		require_once HANDY_CUSTOM_PLUGIN_DIR . 'includes/class-base-utils.php';
 		
 		// Admin functionality (load conditionally)
 		if (is_admin()) {
@@ -68,9 +69,6 @@ class Handy_Custom {
 		// Frontend functionality (load conditionally)
 		if (!is_admin()) {
 			require_once HANDY_CUSTOM_PLUGIN_DIR . 'includes/class-shortcodes.php';
-			
-			// Base utilities (required by both products and recipes)
-			require_once HANDY_CUSTOM_PLUGIN_DIR . 'includes/class-base-utils.php';
 			
 			// Product-specific functionality
 			require_once HANDY_CUSTOM_PLUGIN_DIR . 'includes/products/class-products-utils.php';

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -99,6 +99,9 @@ class Handy_Custom {
 		// Initialize cache invalidation hooks
 		Handy_Custom_Base_Utils::init_cache_invalidation();
 		
+		// Clear cache if plugin version has changed
+		Handy_Custom_Base_Utils::clear_version_cache();
+		
 		// Initialize admin functionality
 		if (is_admin()) {
 			Handy_Custom_Admin::init();


### PR DESCRIPTION
## Summary
- Fixed broken frontend categories display caused by cache format changes between v1.3.0 and v1.5.0
- Optimized admin product filters to show only priority taxonomies for streamlined interface

## Changes Made

### Frontend Categories Fix
- **Problem**: Product categories page was showing "No categories found" instead of the 4 expected top-level categories
- **Root Cause**: Cache key generation changed from `serialize()` to `wp_json_encode()` between versions, causing stale cached data
- **Solution**: Added version-based cache invalidation that automatically clears cache when plugin version changes
- **Files Modified**: `includes/class-base-utils.php`, `includes/class-handy-custom.php`

### Admin Filters Optimization  
- **Problem**: Admin product listing showed too many filter dropdowns (10 taxonomies)
- **Solution**: Streamlined to show only 5 priority taxonomies in order of importance:
  1. Market Segment
  2. Cooking Method
  3. Product Type
  4. Grade
  5. Size
- **Files Modified**: `includes/class-admin.php`

### Version Update
- Updated plugin version from 1.5.0 to 1.5.1
- Updated README badge to reflect new version

## Test Plan
- [x] Verify frontend `/products` page displays 4 top-level categories correctly
- [x] Verify frontend filter dropdowns work properly (all taxonomies except product-category)
- [x] Verify admin product listing shows only 5 priority filter dropdowns
- [x] Verify admin filters function correctly with AND logic
- [x] Verify cache invalidation works on version upgrades
- [x] Check for PHP syntax errors in modified files

🤖 Generated with [Claude Code](https://claude.ai/code)