### PR TITLE
Fix frontend filters display and admin category filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![WordPress](https://img.shields.io/badge/WordPress-5.3%2B-blue.svg)
 ![PHP](https://img.shields.io/badge/PHP-7.2%2B-purple.svg)
-![Version](https://img.shields.io/badge/version-1.5.2-green.svg)
+![Version](https://img.shields.io/badge/version-1.5.3-green.svg)
 ![License](https://img.shields.io/badge/license-GPL--2.0-orange.svg)
 
 A powerful WordPress plugin providing advanced product and recipe archive functionality with AJAX filtering, SEO-friendly URLs, and hierarchical category management.
@@ -371,7 +371,13 @@ See [IMPORT_README.md](IMPORT_README.md) for detailed instructions and field map
 
 ## 📝 Changelog
 
-### Version 1.5.2 (Latest)
+### Version 1.5.3 (Latest)
+- **Frontend Filter Display**: Fixed grade and other taxonomy filters not appearing on frontend when using `[products]` shortcode in categories mode
+- **Admin Category Filter Enhancement**: Fixed admin product category dropdown to display all categories (both parent and child) in hierarchical structure
+- **User Experience**: Restored complete filter interface on frontend products page to match design requirements
+- **Admin Interface**: Improved category filtering functionality for better product management workflow
+
+### Version 1.5.2
 - **Bug Fix**: Fixed category display order not appearing correctly when categories lack display_order meta field
 - **Admin Filter Cleanup**: Removed grade dropdown from admin product filtering interface
 - **Query Optimization**: Changed category retrieval from meta-key based query to fetch-all-then-sort approach

--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.5.2
+ * Version:           1.5.3
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -64,10 +64,11 @@ class Handy_Custom_Admin {
                 'order' => 'ASC'
             );
             
-            // For product categories, show hierarchical structure
+            // For product categories, show hierarchical structure with proper ordering
             if ($taxonomy === 'product-category') {
-                $terms_args['orderby'] = 'meta_value_num name';
-                $terms_args['meta_key'] = 'display_order';
+                // Don't use meta_key restriction to include all categories
+                $terms_args['orderby'] = 'name';
+                $terms_args['order'] = 'ASC';
             }
             
             $terms = get_terms($terms_args);

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.5.2';
+	const VERSION = '1.5.3';
 
 	/**
 	 * Single instance of the class

--- a/includes/products/class-products-renderer.php
+++ b/includes/products/class-products-renderer.php
@@ -24,14 +24,14 @@ class Handy_Custom_Products_Renderer {
 		// Get display mode (default to 'categories')
 		$display_mode = isset($filters['display']) ? $filters['display'] : 'categories';
 		
-		// Determine if we should include category filter (only for list mode)
+		// Always show filters in both modes, but category filter only in list mode
 		$include_category_filter = ($display_mode === 'list');
 
 		// Load the main archive template with appropriate data
 		$template_vars = array(
 			'filters' => $filters,
 			'display_mode' => $display_mode,
-			'filter_options' => $this->get_filter_options($include_category_filter)
+			'filter_options' => $this->get_filter_options($include_category_filter, true) // Always show filters
 		);
 
 		// Add data based on display mode
@@ -70,9 +70,13 @@ class Handy_Custom_Products_Renderer {
 	 * Get filter options for dropdowns
 	 *
 	 * @param bool $include_category_filter Whether to include category filter
+	 * @param bool $force_show_filters Whether to force showing filters even in categories mode
 	 * @return array
 	 */
-	private function get_filter_options($include_category_filter = false) {
+	private function get_filter_options($include_category_filter = false, $force_show_filters = false) {
+		if (!$force_show_filters && !$include_category_filter) {
+			return array(); // Don't show filters unless forced or in list mode
+		}
 		return Handy_Custom_Products_Filters::get_filter_options(array(), $include_category_filter);
 	}
 


### PR DESCRIPTION
## Summary

- **Frontend Filter Display**: Fixed grade and other taxonomy filters not appearing on frontend when using `[products]` shortcode in categories mode  
- **Admin Category Filter Enhancement**: Fixed admin product category dropdown to display all categories (both parent and child) in hierarchical structure

## Changes Made

### Frontend Fixes
- Modified `Handy_Custom_Products_Renderer::get_filter_options()` to accept `force_show_filters` parameter
- Updated renderer logic to always show filters in both categories and list display modes
- Ensured grade, market segment, cooking method, menu occasion, product type, and size filters display correctly

### Admin Fixes  
- Removed `meta_key` restriction from admin category filter query to include all categories
- Fixed hierarchical display to show both parent and child categories in dropdown
- Maintained proper indentation for subcategories with "— " prefix

### Version & Documentation
- Updated plugin version to 1.5.3 in header and class constant
- Added comprehensive changelog entry in README.md
- Updated version badge to reflect v1.5.3

## Test Plan

### Frontend Testing
- [ ] Visit `/products` page with `[products]` shortcode  
- [ ] Verify all filter dropdowns appear (Grade, Market Segment, Cooking Method, Menu Occasion, Product Type, Size)
- [ ] Confirm filters match the HTML structure provided by user
- [ ] Test filter functionality works correctly

### Admin Testing
- [ ] Navigate to WordPress Admin → Products → All Products
- [ ] Verify Category dropdown shows both parent and child categories
- [ ] Confirm hierarchical structure with subcategory indentation
- [ ] Test filtering works with both parent and child category selections

🤖 Generated with [Claude Code](https://claude.ai/code)