### PR TITLE
Fix single product URLs to serve content directly on clean URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![WordPress](https://img.shields.io/badge/WordPress-5.3%2B-blue.svg)
 ![PHP](https://img.shields.io/badge/PHP-7.2%2B-purple.svg)
-![Version](https://img.shields.io/badge/version-1.6.4-green.svg)
+![Version](https://img.shields.io/badge/version-1.6.5-green.svg)
 ![License](https://img.shields.io/badge/license-GPL--2.0-orange.svg)
 
 A powerful WordPress plugin providing advanced product and recipe archive functionality with AJAX filtering, SEO-friendly URLs, and hierarchical category management.
@@ -413,7 +413,16 @@ See [IMPORT_README.md](IMPORT_README.md) for detailed instructions and field map
 
 ## 📝 Changelog
 
-### Version 1.6.4 (Latest)
+### Version 1.6.5 (Latest)
+- **WordPress Page Hierarchy Fix**: Plugin no longer interferes with creating WordPress pages under /products/ parent
+- **Flatsome UX Builder Compatibility**: Can now create `/products/crab/` pages and set parent/child relationships without errors
+- **Smart URL Detection**: Plugin checks for existing WordPress pages before applying rewrite rules
+- **Page Creation Freedom**: WordPress admin page creation and hierarchy management works normally
+- **Direct Single Product URLs**: Single product URLs like `/products/appetizers/ultimate-mini-crab-cakes/` serve content directly without redirecting
+- **Enhanced URL Structure**: Products maintain clean category-based URLs while displaying proper single product content
+- **Improved Yoast Integration**: Better breadcrumb support for single product pages on clean URLs
+
+### Version 1.6.4
 - **Direct Single Product URLs**: Single product URLs like `/products/appetizers/ultimate-mini-crab-cakes/` now serve content directly without redirecting
 - **Enhanced URL Structure**: Products maintain clean category-based URLs while displaying proper single product content
 - **Improved Yoast Integration**: Better breadcrumb support for single product pages on clean URLs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![WordPress](https://img.shields.io/badge/WordPress-5.3%2B-blue.svg)
 ![PHP](https://img.shields.io/badge/PHP-7.2%2B-purple.svg)
-![Version](https://img.shields.io/badge/version-1.6.3-green.svg)
+![Version](https://img.shields.io/badge/version-1.6.4-green.svg)
 ![License](https://img.shields.io/badge/license-GPL--2.0-orange.svg)
 
 A powerful WordPress plugin providing advanced product and recipe archive functionality with AJAX filtering, SEO-friendly URLs, and hierarchical category management.
@@ -413,7 +413,15 @@ See [IMPORT_README.md](IMPORT_README.md) for detailed instructions and field map
 
 ## 📝 Changelog
 
-### Version 1.6.3 (Latest)
+### Version 1.6.4 (Latest)
+- **Direct Single Product URLs**: Single product URLs like `/products/appetizers/ultimate-mini-crab-cakes/` now serve content directly without redirecting
+- **Enhanced URL Structure**: Products maintain clean category-based URLs while displaying proper single product content
+- **Improved Yoast Integration**: Better breadcrumb support for single product pages on clean URLs
+- **WordPress Query Optimization**: Proper query variable setup for single product display on custom URLs
+- **Template System Enhancement**: Single products use WordPress's native template system while preserving clean URLs
+- **Category Context Preservation**: Single product pages maintain category context for navigation and breadcrumbs
+
+### Version 1.6.3
 - **Fixed Page Editing Interference**: Removed plugin interference with WordPress page editing functionality
 - **Enhanced Admin Context Handling**: Added proper admin context checks to prevent template_redirect issues
 - **Single Product URL Support**: Implemented `/products/{category}/{product-slug}/` URL structure for individual products

--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.6.3
+ * Version:           1.6.4
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.6.3');
+define('HANDY_CUSTOM_VERSION', '1.6.4');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.6.4
+ * Version:           1.6.5
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.6.4');
+define('HANDY_CUSTOM_VERSION', '1.6.5');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.6.4';
+	const VERSION = '1.6.5';
 
 	/**
 	 * Single instance of the class

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.6.3';
+	const VERSION = '1.6.4';
 
 	/**
 	 * Single instance of the class


### PR DESCRIPTION
## Summary
- Fixed single product URLs to serve content directly on `/products/{category}/{product-slug}/` format without redirecting
- URLs like `/products/appetizers/ultimate-mini-crab-cakes/` now display content directly instead of redirecting to default WordPress URLs
- Enhanced Yoast breadcrumb integration for single product pages on clean URLs

## Test plan
- [ ] Test single product URLs display content directly (e.g., `/products/appetizers/ultimate-mini-crab-cakes/`)
- [ ] Verify Yoast breadcrumbs work correctly with `[wpseo_breadcrumb]` shortcode on single product pages
- [ ] Confirm category context is preserved for navigation and breadcrumbs
- [ ] Test that WordPress template system works properly with clean URLs
- [ ] Verify no 404 errors occur for valid product/category combinations

🤖 Generated with [Claude Code](https://claude.ai/code)