### PR TITLE
Fix fatal error on products page - add missing get_url_parameters method

### DIFF
--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.6.7
+ * Version:           1.6.8
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.6.7';
+	const VERSION = '1.6.8';
 
 	/**
 	 * Single instance of the class
@@ -510,6 +510,30 @@ class Handy_Custom {
 		return isset($GLOBALS['handy_custom_single_product_category']) 
 			? $GLOBALS['handy_custom_single_product_category'] 
 			: false;
+	}
+
+	/**
+	 * Get URL parameters from the current request
+	 * Extracts category and product slug from rewrite rules
+	 * 
+	 * @return array URL parameters array
+	 */
+	public static function get_url_parameters() {
+		$params = array();
+		
+		// Get category from query var (set by rewrite rules)
+		$category = get_query_var('product_category');
+		if (!empty($category)) {
+			$params['category'] = $category;
+		}
+		
+		// Get product slug from query var (set by rewrite rules)
+		$product_slug = get_query_var('product_slug');
+		if (!empty($product_slug)) {
+			$params['product_slug'] = $product_slug;
+		}
+		
+		return $params;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Fixes fatal error: "Call to undefined method Handy_Custom::get_url_parameters()" on /products page
- Adds missing static method to extract URL parameters from WordPress query variables

## Test plan
- [ ] Visit /products page and verify no fatal error occurs
- [ ] Test product category URLs work correctly
- [ ] Verify URL parameters are properly extracted from rewrite rules

🤖 Generated with [Claude Code](https://claude.ai/code)