### PR TITLE
Shop Now Buttons with ACF Integration and Enhanced Clear Filters UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![WordPress](https://img.shields.io/badge/WordPress-5.3%2B-blue.svg)
 ![PHP](https://img.shields.io/badge/PHP-7.2%2B-purple.svg)
-![Version](https://img.shields.io/badge/version-1.7.3-green.svg)
+![Version](https://img.shields.io/badge/version-1.7.4-green.svg)
 ![License](https://img.shields.io/badge/license-GPL--2.0-orange.svg)
 
 A powerful WordPress plugin providing advanced product and recipe archive functionality with AJAX filtering, SEO-friendly URLs, and hierarchical category management.
@@ -247,13 +247,23 @@ URL parameters automatically merge with shortcode attributes.
 Create these custom fields for enhanced functionality:
 
 ```php
-// For category terms
-'category_featured_image' // Image field for category cards
+// For category terms (product-category and recipe-category taxonomies)
+'category_featured_image'                              // Image field for category cards
+'internal_url_for_this_product_category_or_subcategory' // URL field for Shop Now buttons (v1.7.4+)
 
 // For recipe posts  
 'prep_time'              // Number field (minutes)
 'servings'               // Number field
 ```
+
+**New in Version 1.7.4: Shop Now URLs**
+
+Category Shop Now buttons now use the ACF field `internal_url_for_this_product_category_or_subcategory`:
+- **Field Type**: URL field
+- **Applied To**: Both `product-category` and `recipe-category` taxonomies  
+- **Format**: Internal paths like `/products/crab/crab-cakes`
+- **Validation**: Must start with `/products/` for security
+- **Fallback**: If empty, buttons link to category page URL
 
 ### Asset Customization
 
@@ -439,7 +449,15 @@ See [IMPORT_README.md](IMPORT_README.md) for detailed instructions and field map
 
 ## 📝 Changelog
 
-### Version 1.7.3 (Latest)
+### Version 1.7.4 (Latest)
+- **Shop Now Buttons with ACF Integration**: Category cards now use ACF field `internal_url_for_this_product_category_or_subcategory` for Shop Now button URLs
+- **URL Validation for Shop Now**: Added security validation ensuring Shop Now URLs start with `/products/` and are internal to the site
+- **Enhanced Clear Filters UX**: Moved Clear Filters button from products grid to filter shortcode for better organization
+- **Conditional Clear Filters**: Clear Filters button only appears when filters are actively selected, improving UI clarity
+- **Smart Fallback for Shop Now**: If no ACF URL is set, Shop Now buttons fallback to category page URLs instead of dead links
+- **Filter State Detection**: Added intelligent detection of active filters to control Clear Filters button visibility
+
+### Version 1.7.3
 - **Fixed Subcategory Display Logic**: `[products subcategory="gluten-free"]` now correctly shows product list instead of category cards
 - **Enhanced Category Filtering**: Categories without subcategories (like shrimp) automatically display as product lists instead of empty category cards
 - **Improved Filter Context**: `[filter-products subcategory="gluten-free"]` now only shows filter options actually used by products in that subcategory

--- a/assets/js/filters.js
+++ b/assets/js/filters.js
@@ -40,8 +40,8 @@
                 this.handleFilterChange(event);
             });
             
-            // Handle clear filters button
-            $(document).on('click', '.btn-clear-filters', (event) => {
+            // Handle clear filters button (both old and new classes)
+            $(document).on('click', '.btn-clear-filters, .btn-clear-filters-main', (event) => {
                 this.handleClearFilters(event);
             });
             

--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.7.3
+ * Version:           1.7.4
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.7.3');
+define('HANDY_CUSTOM_VERSION', '1.7.4');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-filters-renderer.php
+++ b/includes/class-filters-renderer.php
@@ -358,6 +358,36 @@ class Handy_Custom_Filters_Renderer {
 	}
 
 	/**
+	 * Check if any filters are currently active
+	 * Used to determine whether to show Clear Filters button
+	 *
+	 * @param array $filters Current filter values from URL or form
+	 * @return bool True if any filters are active
+	 */
+	public function has_active_filters($filters = array()) {
+		// If no filters passed, get from URL parameters
+		if (empty($filters)) {
+			$filters = $_GET;
+		}
+
+		// Define filter keys to check (excluding pagination and display parameters)
+		$filter_keys = array(
+			'category', 'subcategory', 'grade', 'market_segment', 
+			'cooking_method', 'menu_occasion', 'product_type', 'size'
+		);
+
+		foreach ($filter_keys as $key) {
+			if (!empty($filters[$key]) && $filters[$key] !== '') {
+				Handy_Custom_Logger::log("Active filter detected: {$key} = {$filters[$key]}", 'debug');
+				return true;
+			}
+		}
+
+		Handy_Custom_Logger::log('No active filters detected', 'debug');
+		return false;
+	}
+
+	/**
 	 * Load unified filter template
 	 *
 	 * @param string $content_type Content type (products/recipes)
@@ -380,7 +410,10 @@ class Handy_Custom_Filters_Renderer {
 		// Extract variables for template use
 		$filters = $current_filters;
 		
-		Handy_Custom_Logger::log("Loading filter template for {$content_type} with " . count($filter_options) . " filter groups", 'info');
+		// Add active filter detection for template
+		$has_active_filters = $this->has_active_filters($current_filters);
+		
+		Handy_Custom_Logger::log("Loading filter template for {$content_type} with " . count($filter_options) . " filter groups, active filters: " . ($has_active_filters ? 'yes' : 'no'), 'info');
 
 		// Include template
 		include $template_path;

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.7.3';
+	const VERSION = '1.7.4';
 
 	/**
 	 * Single instance of the class

--- a/includes/products/class-products-display.php
+++ b/includes/products/class-products-display.php
@@ -177,14 +177,29 @@ class Handy_Custom_Products_Display {
 	}
 
 	/**
-	 * Generate shop now URL (placeholder)
+	 * Get Shop Now URL from ACF field for category
 	 *
 	 * @param object $category Category term object
-	 * @return string
+	 * @return string Shop Now URL or fallback URL
 	 */
 	public static function get_shop_now_url($category) {
-		// TODO: Implement shop now functionality later
-		// Return dead link as requested
-		return '#';
+		if (empty($category) || !isset($category->term_id)) {
+			Handy_Custom_Logger::log('Invalid category object passed to get_shop_now_url', 'warning');
+			return '#';
+		}
+
+		// Use the utility function to get validated URL
+		$shop_url = Handy_Custom_Products_Utils::get_shop_now_url($category);
+		
+		if ($shop_url) {
+			Handy_Custom_Logger::log("Shop Now URL found for category {$category->slug}: {$shop_url}", 'debug');
+			return $shop_url;
+		}
+
+		// Fallback: if no shop URL is set, return the category page URL as fallback
+		$fallback_url = self::get_category_page_url($category);
+		Handy_Custom_Logger::log("No Shop Now URL set for category {$category->slug}, using fallback: {$fallback_url}", 'info');
+		
+		return $fallback_url;
 	}
 }

--- a/templates/shortcodes/filters/archive.php
+++ b/templates/shortcodes/filters/archive.php
@@ -76,14 +76,14 @@ Handy_Custom_Logger::log("Available filter groups: " . wp_json_encode(array_keys
         </div>
         
         <!-- Clear Filters Button (only show if filters are applied) -->
-        <?php if (!empty(array_filter($filters))): ?>
+        <?php if (isset($has_active_filters) && $has_active_filters): ?>
             <div class="filter-actions">
-                <button type="button" class="btn btn-clear-filters" 
+                <button type="button" class="btn btn-clear-filters-main" 
                         data-content-type="<?php echo esc_attr($content_type); ?>">
                     Clear All Filters
                 </button>
             </div>
-            <?php Handy_Custom_Logger::log("Clear filters button displayed - active filters: " . wp_json_encode(array_filter($filters)), 'debug'); ?>
+            <?php Handy_Custom_Logger::log("Clear filters button displayed - active filters detected", 'debug'); ?>
         <?php endif; ?>
         
     <?php else: ?>

--- a/templates/shortcodes/products/archive.php
+++ b/templates/shortcodes/products/archive.php
@@ -109,9 +109,6 @@ Handy_Custom_Logger::log($context_info . " (CSS class: {$container_class})", 'in
                 <!-- No Products Found -->
                 <div class="no-results">
                     <p>No products found matching the selected filters.</p>
-                    <?php if (!empty(array_filter($filters))): ?>
-                        <button type="button" class="btn btn-clear-filters">Clear Filters</button>
-                    <?php endif; ?>
                 </div>
                 
             <?php endif; ?>
@@ -190,9 +187,6 @@ Handy_Custom_Logger::log($context_info . " (CSS class: {$container_class})", 'in
                 <!-- No Categories Found -->
                 <div class="no-results">
                     <p>No categories found matching the selected filters.</p>
-                    <?php if (!empty(array_filter($filters))): ?>
-                        <button type="button" class="btn btn-clear-filters">Clear Filters</button>
-                    <?php endif; ?>
                 </div>
                 
             <?php endif; ?>


### PR DESCRIPTION
## Summary
- **Shop Now Buttons**: Category cards now use ACF field `internal_url_for_this_product_category_or_subcategory` for dynamic Shop Now URLs
- **Clear Filters UX**: Moved Clear Filters button from products grid to filter shortcode with conditional display
- **URL Validation**: Added security validation ensuring Shop Now URLs are internal `/products/` paths only
- **Smart Fallbacks**: Shop Now buttons fallback to category page URLs when ACF field is empty

## Key Changes

### Shop Now Button Implementation
- Added `validate_shop_now_url()` and `get_shop_now_url()` utility functions in Products Utils
- Updated Products Display class to integrate with ACF field for Shop Now URLs
- Shop Now buttons now use `get_field('internal_url_for_this_product_category_or_subcategory')`
- URL validation prevents external links and ensures `/products/` prefix for security
- Fallback to category page URL when no Shop Now URL is configured

### Clear Filters Enhancement
- Moved Clear Filters button from products template "no results" section to filter shortcode
- Added `has_active_filters()` method to Filters Renderer for intelligent button display
- Clear Filters button now only appears when filters are actively selected
- Updated filter template to use new `btn-clear-filters-main` CSS class
- Enhanced JavaScript to handle both old and new Clear Filters button classes

### User Experience Improvements
- Shop Now buttons provide actual navigation instead of dead `#` links
- Clear Filters button placement is more logical and consistent
- Conditional Clear Filters reduces UI clutter when no filters are active
- Comprehensive logging for debugging Shop Now URL validation

## Technical Details
- **New ACF Field**: `internal_url_for_this_product_category_or_subcategory` (URL field)
- **Security**: URL validation prevents JavaScript injection and external links
- **Compatibility**: JavaScript handles both `.btn-clear-filters` and `.btn-clear-filters-main` classes
- **Fallback Logic**: Graceful degradation when ACF field is empty or invalid
- **Version**: Plugin updated to v1.7.4 with comprehensive documentation

## Test Plan
- [ ] Verify Shop Now buttons use ACF URLs when configured
- [ ] Test URL validation rejects external and malformed URLs
- [ ] Confirm Clear Filters button appears only when filters are active
- [ ] Test Clear Filters functionality clears all filters and updates URL
- [ ] Verify fallback behavior when Shop Now URLs are not configured
- [ ] Test across all category card types (top-level and subcategories)

🤖 Generated with [Claude Code](https://claude.ai/code)