### PR TITLE
Update button links and standardize content width to 1440px

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![WordPress](https://img.shields.io/badge/WordPress-5.3%2B-blue.svg)
 ![PHP](https://img.shields.io/badge/PHP-7.2%2B-purple.svg)
-![Version](https://img.shields.io/badge/version-1.7.5-green.svg)
+![Version](https://img.shields.io/badge/version-1.8.0-green.svg)
 ![License](https://img.shields.io/badge/license-GPL--2.0-orange.svg)
 
 A powerful WordPress plugin providing advanced product and recipe archive functionality with AJAX filtering, SEO-friendly URLs, and hierarchical category management.
@@ -256,14 +256,15 @@ Create these custom fields for enhanced functionality:
 'servings'               // Number field
 ```
 
-**New in Version 1.7.4: Shop Now URLs**
+**New in Version 1.8.0: Updated Button Functionality**
 
-Category Shop Now buttons now use the ACF field `internal_url_for_this_product_category_or_subcategory`:
-- **Field Type**: URL field
-- **Applied To**: Both `product-category` and `recipe-category` taxonomies  
-- **Format**: Internal paths like `/products/crab/crab-cakes`
+Category card buttons have been updated with new functionality:
+- **Shop Now Buttons**: Now link to `/product-locator/` page for all categories
+- **Find Out More Buttons**: Use the ACF field `internal_url_for_this_product_category_or_subcategory` for custom URLs
+- **Field Type**: URL field (applied to both `product-category` and `recipe-category` taxonomies)
+- **Format**: Internal paths like `/products/crab/crab-cakes` 
 - **Validation**: Must start with `/products/` for security
-- **Fallback**: If empty, buttons link to category page URL
+- **Fallback**: If ACF field is empty, Find Out More buttons link to category page URL
 
 ### Asset Customization
 
@@ -449,7 +450,14 @@ See [IMPORT_README.md](IMPORT_README.md) for detailed instructions and field map
 
 ## 📝 Changelog
 
-### Version 1.7.5 (Latest)
+### Version 1.8.0 (Latest)
+- **Updated Button Links**: Shop Now buttons now link to `/product-locator/` instead of category pages
+- **Swapped Button Functions**: Find Out More buttons now use ACF field `internal_url_for_this_product_category_or_subcategory` (previously used by Shop Now)
+- **Uniform Content Width**: Standardized all content areas to 1440px width for consistent layout
+- **Standardized Card Layout**: All category/subcategory cards now use 695px width with 35px gaps and 240px outer padding on desktop
+- **Improved Responsive Design**: Updated breakpoints to 1600px with consistent padding (40px tablet, 20px mobile)
+
+### Version 1.7.5
 - **Fixed Shop Now Button URLs**: Shop Now buttons now correctly use `/products/{category}/` format instead of `/product-category/{category}/`
 - **Improved URL Fallback**: When ACF field `internal_url_for_this_product_category_or_subcategory` is empty, fallback URLs now use custom products URL structure
 - **Enhanced Category URL Generation**: Updated `get_category_page_url()` to use `Handy_Custom_Products_Utils::get_category_url()` for consistent URL formatting

--- a/assets/css/filters.css
+++ b/assets/css/filters.css
@@ -17,10 +17,10 @@
     border-radius: 8px;
     padding: 20px;
     margin-bottom: 30px;
+    margin-left: 240px;
+    margin-right: 240px;
     position: relative;
     max-width: 1440px;
-    margin-left: auto;
-    margin-right: auto;
 }
 
 .handy-filters[data-content-type="products"] {
@@ -193,8 +193,8 @@
    Responsive Design
    ========================================================================== */
 
-/* Tablet (550-849px) */
-@media (max-width: 849px) and (min-width: 550px) {
+/* Tablet (550-1600px) */
+@media (max-width: 1600px) and (min-width: 550px) {
     .filters-row {
         gap: 15px;
     }
@@ -206,6 +206,8 @@
     
     .handy-filters {
         padding: 15px;
+        margin-left: 40px;
+        margin-right: 40px;
     }
 }
 
@@ -224,6 +226,8 @@
     .handy-filters {
         padding: 15px;
         margin-bottom: 20px;
+        margin-left: 20px;
+        margin-right: 20px;
     }
     
     .filter-group label {

--- a/assets/css/filters.css
+++ b/assets/css/filters.css
@@ -8,7 +8,7 @@
  */
 
 /* ==========================================================================
-   Filter Container Styles - 1420px site content width
+   Filter Container Styles - 1440px uniform content width
    ========================================================================== */
 
 .handy-filters {
@@ -18,7 +18,7 @@
     padding: 20px;
     margin-bottom: 30px;
     position: relative;
-    max-width: 1420px;
+    max-width: 1440px;
     margin-left: auto;
     margin-right: auto;
 }

--- a/assets/css/products/archive.css
+++ b/assets/css/products/archive.css
@@ -3,21 +3,18 @@
  * Basic CSS structure for products shortcode template
  */
 
-/* Main Container - Default 1730px for top-level categories */
+/* Main Container - Uniform 1440px content width */
 .handy-products-archive {
-    max-width: 1730px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 20px;
 }
 
 /* Container width adjustments for different display modes */
-.handy-products-archive.products-top-level {
-    max-width: 1730px;
-}
-
+.handy-products-archive.products-top-level,
 .handy-products-archive.products-subcategory,
 .handy-products-archive.products-list {
-    max-width: 1451px;
+    max-width: 1440px;
 }
 
 /* Filter Controls Removed: Now handled by unified filter system via [filter-products] shortcode */
@@ -35,18 +32,20 @@
     margin: 0 auto;
 }
 
-/* Top-level categories: 2 columns, 850px cards, 31px gap */
+/* Top-level categories: 2 columns adjusted for 1440px width */
 .products-top-level .products-category-view {
-    grid-template-columns: repeat(2, 850px);
-    gap: 31px;
-    justify-content: center;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 40px;
+    max-width: 1400px;
+    margin: 0 auto;
 }
 
-/* Subcategories: 2 columns, 696px cards, 38px gap */
+/* Subcategories: 2 columns adjusted for 1440px width */
 .products-subcategory .products-category-view {
-    grid-template-columns: repeat(2, 696px);
-    gap: 38px;
-    justify-content: center;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 40px;
+    max-width: 1400px;
+    margin: 0 auto;
 }
 
 /* Product List View Grid - 2 columns for 1420px content width */

--- a/assets/css/products/archive.css
+++ b/assets/css/products/archive.css
@@ -3,11 +3,11 @@
  * Basic CSS structure for products shortcode template
  */
 
-/* Main Container - Uniform 1440px content width */
+/* Main Container - Uniform 1440px content width with standardized padding */
 .handy-products-archive {
     max-width: 1440px;
     margin: 0 auto;
-    padding: 20px;
+    padding: 20px 240px;
 }
 
 /* Container width adjustments for different display modes */
@@ -32,20 +32,12 @@
     margin: 0 auto;
 }
 
-/* Top-level categories: 2 columns adjusted for 1440px width */
-.products-top-level .products-category-view {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 40px;
-    max-width: 1400px;
-    margin: 0 auto;
-}
-
-/* Subcategories: 2 columns adjusted for 1440px width */
+/* Standardized category cards: 695px width, 35px gap */
+.products-top-level .products-category-view,
 .products-subcategory .products-category-view {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 40px;
-    max-width: 1400px;
-    margin: 0 auto;
+    grid-template-columns: repeat(2, 695px);
+    gap: 35px;
+    justify-content: center;
 }
 
 /* Product List View Grid - 2 columns for 1420px content width */
@@ -326,17 +318,17 @@
     }
 }
 
-/* Tablet: 550px to 1450px */
-@media (max-width: 1450px) {
+/* Tablet: 1600px and below - adjust for standardized card layout */
+@media (max-width: 1600px) {
     .handy-products-archive {
-        padding: 15px;
+        padding: 15px 40px;
     }
     
-    /* Category view - responsive 2 columns on tablet */
+    /* Category view - responsive 2 columns maintaining proportional gap */
     .products-top-level .products-category-view,
     .products-subcategory .products-category-view {
         grid-template-columns: repeat(2, 1fr);
-        gap: 20px;
+        gap: 35px;
         max-width: 100%;
     }
     
@@ -358,14 +350,14 @@
 /* Mobile: 549px and below */
 @media (max-width: 549px) {
     .handy-products-archive {
-        padding: 10px;
+        padding: 10px 20px;
     }
     
     /* Category view - 1 column on mobile */
     .products-top-level .products-category-view,
     .products-subcategory .products-category-view {
         grid-template-columns: 1fr;
-        gap: 15px;
+        gap: 35px;
     }
     
     /* Product list view - 1 column on mobile */

--- a/assets/css/recipes/archive.css
+++ b/assets/css/recipes/archive.css
@@ -4,9 +4,9 @@
  * Features recipe-specific layout with prep time and servings display
  */
 
-/* Main Container - 1420px site content width */
+/* Main Container - 1440px uniform content width */
 .handy-recipes-archive {
-    max-width: 1420px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 20px;
 }

--- a/assets/css/recipes/archive.css
+++ b/assets/css/recipes/archive.css
@@ -4,11 +4,11 @@
  * Features recipe-specific layout with prep time and servings display
  */
 
-/* Main Container - 1440px uniform content width */
+/* Main Container - 1440px uniform content width with standardized padding */
 .handy-recipes-archive {
     max-width: 1440px;
     margin: 0 auto;
-    padding: 20px;
+    padding: 20px 240px;
 }
 
 /* Archive Header */
@@ -47,11 +47,11 @@
 
 /* Filter Controls Removed: Now handled by unified filter system via [filter-recipes] shortcode */
 
-/* Recipes Grid - 4-column layout for 1420px content width (matches design example) */
+/* Recipes Grid - 4-column layout with standardized 35px gap */
 .handy-recipes-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    gap: 30px;
+    gap: 35px;
     margin-bottom: 30px;
 }
 
@@ -239,16 +239,16 @@
     font-size: 16px;
 }
 
-/* Responsive Design - Match site breakpoints: 850px+, 550-849px, 549px- */
-/* Tablet: 550px to 849px - 2 columns */
-@media (max-width: 849px) and (min-width: 550px) {
+/* Responsive Design - Match standardized breakpoints */
+/* Tablet: 550px to 1600px - 2 columns */
+@media (max-width: 1600px) and (min-width: 550px) {
     .handy-recipes-archive {
-        padding: 15px;
+        padding: 15px 40px;
     }
     
     .handy-recipes-grid {
         grid-template-columns: repeat(2, 1fr);
-        gap: 25px;
+        gap: 35px;
     }
     
     .recipe-card-content {
@@ -259,7 +259,7 @@
 /* Mobile: 549px and below */
 @media (max-width: 549px) {
     .handy-recipes-archive {
-        padding: 10px;
+        padding: 10px 20px;
     }
     
     .recipes-archive-header {
@@ -274,7 +274,7 @@
     
     .handy-recipes-grid {
         grid-template-columns: 1fr;
-        gap: 20px;
+        gap: 35px;
     }
     
     .recipe-card-content {

--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.7.5
+ * Version:           1.8.0
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.7.4');
+define('HANDY_CUSTOM_VERSION', '1.8.0');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.7.5';
+	const VERSION = '1.8.0';
 
 	/**
 	 * Single instance of the class

--- a/templates/shortcodes/products/archive.php
+++ b/templates/shortcodes/products/archive.php
@@ -172,8 +172,8 @@ Handy_Custom_Logger::log($context_info . " (CSS class: {$container_class})", 'in
                             
                             <!-- Action Buttons -->
                             <div class="category-actions">
-                                <a href="<?php echo esc_url($shop_url); ?>" class="btn btn-shop">Shop Now</a>
-                                <a href="<?php echo esc_url($category_url); ?>" class="btn btn-learn">Find Out More</a>
+                                <a href="/product-locator/" class="btn btn-shop">Shop Now</a>
+                                <a href="<?php echo esc_url($shop_url); ?>" class="btn btn-learn">Find Out More</a>
                             </div>
                             
                         </div>


### PR DESCRIPTION
## Summary
- Updated Shop Now buttons to link to `/product-locator/` page instead of category pages
- Find Out More buttons now use ACF field `internal_url_for_this_product_category_or_subcategory` (previously used by Shop Now)
- Standardized all content areas to uniform 1440px width with consistent padding
- Unified category/subcategory card layout with 695px width and 35px gaps across all templates

## Test plan
- [ ] Verify Shop Now buttons on category cards link to `/product-locator/`
- [ ] Confirm Find Out More buttons use ACF field URLs with proper fallback to category URLs
- [ ] Test responsive layout at different breakpoints (1600px, tablet, mobile)
- [ ] Validate consistent 1440px content width across products and recipes pages
- [ ] Check card layout standardization with 695px width and 35px gaps

🤖 Generated with [Claude Code](https://claude.ai/code)