### PR TITLE
Fix auto-updater plugin detection and disable debug logging

### DIFF
--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.8.4
+ * Version:           1.8.5
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,12 +29,12 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.8.4');
+define('HANDY_CUSTOM_VERSION', '1.8.5');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 
 // LOGGING CONTROL - Set to true to enable logging
-define('HANDY_CUSTOM_DEBUG', true);
+define('HANDY_CUSTOM_DEBUG', false);
 
 // Load main plugin class
 require_once plugin_dir_path(__FILE__) . 'includes/class-handy-custom.php';

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.8.4';
+	const VERSION = '1.8.5';
 
 	/**
 	 * Single instance of the class

--- a/includes/class-plugin-updater.php
+++ b/includes/class-plugin-updater.php
@@ -424,7 +424,9 @@ class Handy_Custom_Plugin_Updater {
 		$is_our_plugin = false;
 		
 		// Check multiple possible locations for plugin identification
-		if (isset($upgrader->skin->plugin_info['plugin']) && 
+		if (isset($upgrader->skin->plugin_info) && 
+			is_array($upgrader->skin->plugin_info) &&
+			isset($upgrader->skin->plugin_info['plugin']) &&
 			$upgrader->skin->plugin_info['plugin'] === $this->plugin_basename) {
 			$is_our_plugin = true;
 		} elseif (isset($upgrader->skin->plugin) && 


### PR DESCRIPTION
## Summary
- Fix undefined array key warning in auto-updater plugin detection logic
- Add proper isset() checks before accessing plugin_info array
- Update plugin version to 1.8.5  
- Disable debug logging for production use

## Problem Solved
The auto-updater was generating PHP warnings during the update process:
```
PHP Warning: Undefined array key "plugin" in /wp-content/plugins/handy-custom/includes/class-plugin-updater.php on line 425
```

## Changes Made
1. **Enhanced Plugin Detection**: Added proper isset() checks before accessing `$upgrader->skin->plugin_info['plugin']`
2. **Version Bump**: Updated to v1.8.5 to test the fix
3. **Production Ready**: Disabled debug logging by setting `HANDY_CUSTOM_DEBUG` to false

## Test Plan
- [ ] Merge this PR
- [ ] Create GitHub release v1.8.5 
- [ ] Test auto-updater on production site
- [ ] Verify no PHP warnings in error logs
- [ ] Confirm update completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)