### PR TITLE
Update category buttons: swap icons and dynamic text (v1.9.19)

### DIFF
--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.9.18
+ * Version:           1.9.19
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.9.18');
+define('HANDY_CUSTOM_VERSION', '1.9.19');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.9.18';
+	const VERSION = '1.9.19';
 
 	/**
 	 * Single instance of the class

--- a/includes/products/class-products-utils.php
+++ b/includes/products/class-products-utils.php
@@ -345,4 +345,30 @@ class Handy_Custom_Products_Utils extends Handy_Custom_Base_Utils {
 
 		return false;
 	}
+
+	/**
+	 * Check if a category has child categories
+	 *
+	 * @param int $category_id Category term ID
+	 * @return bool True if category has children
+	 */
+	public static function has_child_categories($category_id) {
+		if (empty($category_id)) {
+			return false;
+		}
+
+		$child_terms = get_terms(array(
+			'taxonomy' => 'product-category',
+			'parent' => $category_id,
+			'hide_empty' => false,
+			'fields' => 'ids'
+		));
+
+		if (is_wp_error($child_terms)) {
+			Handy_Custom_Logger::log("Error checking child categories for ID {$category_id}: " . $child_terms->get_error_message(), 'error');
+			return false;
+		}
+
+		return !empty($child_terms);
+	}
 }

--- a/templates/shortcodes/products/archive.php
+++ b/templates/shortcodes/products/archive.php
@@ -172,8 +172,13 @@ Handy_Custom_Logger::log($context_info . " (CSS class: {$container_class})", 'in
                             
                             <!-- Action Buttons -->
                             <div class="category-actions">
-                                <a href="/product-locator/" class="btn btn-shop"><i class="fa-regular fa-cart-shopping"></i>Shop Now</a>
-                                <a href="<?php echo esc_url($shop_url); ?>" class="btn btn-learn"><i class="fa-regular fa-circle-ellipsis"></i>Find Out More</a>
+                                <?php
+                                // Determine button text based on whether category has children
+                                $has_children = Handy_Custom_Products_Utils::has_child_categories($category->term_id);
+                                $button_text = $has_children ? 'See Options' : 'See Products';
+                                ?>
+                                <a href="/product-locator/" class="btn btn-shop"><i class="fa-regular fa-circle-ellipsis"></i>Shop Now</a>
+                                <a href="<?php echo esc_url($shop_url); ?>" class="btn btn-learn"><i class="fa-regular fa-cart-shopping"></i><?php echo esc_html($button_text); ?></a>
                             </div>
                             
                         </div>


### PR DESCRIPTION
## Summary
- Swapped button icons as requested: ellipsis now on 'Shop Now', cart now on second button
- Added dynamic button text based on category hierarchy:
  - **'See Options'** for categories with children (Appetizers, Dietary Alternatives)
  - **'See Products'** for categories without children (Shrimp, Crab Cakes, Crab Meat, Soft Shell Crab)
- Updated plugin version to 1.9.19

## Changes Made
1. **Added `has_child_categories()` helper function** in `class-products-utils.php`
   - Uses WordPress `get_terms()` with `parent` parameter to detect children
   - Includes proper error handling and logging

2. **Updated template logic** in `templates/shortcodes/products/archive.php`
   - Swapped icons: `fa-circle-ellipsis` → 'Shop Now', `fa-cart-shopping` → second button
   - Dynamic button text based on `has_child_categories()` result
   - Clean PHP logic to determine button text

3. **Updated plugin version** to 1.9.19 across all version constants

## Test Cases
- **Appetizers page**: Should show "See Options" (has 4 children)
- **Dietary Alternatives page**: Should show "See Options" (has 3 children)
- **Shrimp page**: Should show "See Products" (no children)
- **Crab Cakes page**: Should show "See Products" (no children)
- **Crab Meat page**: Should show "See Products" (no children)
- **Soft Shell Crab page**: Should show "See Products" (no children)

## Implementation Notes
- Used iterative commits for clean git history
- Helper function is reusable for other category hierarchy needs
- Template logic is clean and well-commented
- All changes maintain existing functionality while adding new features

🤖 Generated with [Claude Code](https://claude.ai/code)