### PR TITLE
Fix button order: Move Shop Now to bottom (v1.9.20)

### DIFF
--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.9.19
+ * Version:           1.9.20
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.9.19');
+define('HANDY_CUSTOM_VERSION', '1.9.20');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.9.19';
+	const VERSION = '1.9.20';
 
 	/**
 	 * Single instance of the class

--- a/templates/shortcodes/products/archive.php
+++ b/templates/shortcodes/products/archive.php
@@ -177,8 +177,8 @@ Handy_Custom_Logger::log($context_info . " (CSS class: {$container_class})", 'in
                                 $has_children = Handy_Custom_Products_Utils::has_child_categories($category->term_id);
                                 $button_text = $has_children ? 'See Options' : 'See Products';
                                 ?>
-                                <a href="/product-locator/" class="btn btn-shop"><i class="fa-regular fa-circle-ellipsis"></i>Shop Now</a>
-                                <a href="<?php echo esc_url($shop_url); ?>" class="btn btn-learn"><i class="fa-regular fa-cart-shopping"></i><?php echo esc_html($button_text); ?></a>
+                                <a href="<?php echo esc_url($shop_url); ?>" class="btn btn-learn"><i class="fa-regular fa-circle-ellipsis"></i><?php echo esc_html($button_text); ?></a>
+                                <a href="/product-locator/" class="btn btn-shop"><i class="fa-regular fa-cart-shopping"></i>Shop Now</a>
                             </div>
                             
                         </div>


### PR DESCRIPTION
## Summary
This PR fixes the button order issue from v1.9.19 where the buttons were in the wrong positions.

## Changes Made
- **Top button**: Dynamic text ("See Options"/"See Products") with ellipsis icon
- **Bottom button**: "Shop Now" with cart icon
- Update plugin version to 1.9.20

## Problem Fixed
In v1.9.19, the buttons were:
- Top: "Shop Now" with ellipsis icon ❌
- Bottom: Dynamic text with cart icon ❌

Now corrected to:
- Top: Dynamic text with ellipsis icon ✅
- Bottom: "Shop Now" with cart icon ✅

## Expected Results
- **Main products page**: 
  - Appetizers & Dietary Alternatives: "See Options" (top) + "Shop Now" (bottom)
  - Shrimp, Crab Cakes, Crab Meat, Soft Shell Crab: "See Products" (top) + "Shop Now" (bottom)
- **Appetizers subcategory page**: All subcategories show "See Products" (top) + "Shop Now" (bottom)

## Implementation
- Simple template button order swap
- Version increment to 1.9.20
- Fixes the positioning issue identified in live site testing

🤖 Generated with [Claude Code](https://claude.ai/code)