### PR TITLE
Update plugin version to 1.9.21 to trigger auto-updater

### DIFF
--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.9.20
+ * Version:           1.9.21
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.9.20');
+define('HANDY_CUSTOM_VERSION', '1.9.21');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.9.20';
+	const VERSION = '1.9.21';
 
 	/**
 	 * Single instance of the class


### PR DESCRIPTION
## Summary
- Update plugin version from 1.9.20 to 1.9.21 to trigger auto-updater
- This follows the category icons that were added in PR #52
- Version bump will trigger GitHub Actions workflow and WordPress plugin updates

## Changes
- **handy-custom.php**: Update plugin header version to 1.9.21
- **handy-custom.php**: Update HANDY_CUSTOM_VERSION constant to 1.9.21  
- **includes/class-handy-custom.php**: Update Handy_Custom::VERSION constant to 1.9.21

## Test Plan
- [ ] Merge PR and verify GitHub Actions workflow runs
- [ ] Create GitHub release v1.9.21 after merge
- [ ] Confirm WordPress auto-updater detects new version
- [ ] Verify plugin updates successfully on WordPress sites

## Background
PR #52 added 6 missing category icons but didn't include version updates. This PR contains only the version bump needed to trigger the auto-updater system.

🤖 Generated with [Claude Code](https://claude.ai/code)