### PR TITLE
Fix breadcrumb component content alignment

### DIFF
--- a/assets/css/products/single-product.css
+++ b/assets/css/products/single-product.css
@@ -7,7 +7,7 @@
     padding: 20px 30px;
 }
 
-/* Breadcrumbs Section - Full Width Component */
+/* Breadcrumbs Background Component - Full Width */
 .handy-single-product-breadcrumbs-wrapper {
     width: 100vw;
     position: relative;
@@ -21,10 +21,11 @@
     margin-bottom: 40px;
 }
 
+/* Breadcrumbs Content Component - Content Width */
 .handy-single-product-breadcrumbs {
     max-width: 1440px;
     margin: 0 auto;
-    padding: 20px 240px;
+    padding: 20px 30px;
 }
 
 .handy-single-product-breadcrumbs .handy-breadcrumb-nav {

--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.9.22
+ * Version:           1.9.23
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.9.22');
+define('HANDY_CUSTOM_VERSION', '1.9.23');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.9.22';
+	const VERSION = '1.9.23';
 
 	/**
 	 * Single instance of the class


### PR DESCRIPTION
## Summary
• Fix breadcrumb component to properly separate background and content responsibilities
• Remove artificial 240px padding that was preventing natural content alignment
• Breadcrumb content now aligns with main page content using same padding patterns

## Test plan
- [ ] Verify breadcrumb content aligns with main page content on desktop
- [ ] Confirm full-width #E7EDF0 background still spans entire page width
- [ ] Test responsive behavior matches main container padding on tablet and mobile
- [ ] Validate clean separation between background and content components

🤖 Generated with [Claude Code](https://claude.ai/code)