### PR TITLE
Fix product archive pages to show individual product cards

### DIFF
--- a/assets/css/products/single-product.css
+++ b/assets/css/products/single-product.css
@@ -7,7 +7,7 @@
     padding: 20px 30px;
 }
 
-/* Breadcrumbs Section - Full Width Component */
+/* Breadcrumbs Background Component - Full Width */
 .handy-single-product-breadcrumbs-wrapper {
     width: 100vw;
     position: relative;
@@ -21,10 +21,11 @@
     margin-bottom: 40px;
 }
 
+/* Breadcrumbs Content Component - Content Width */
 .handy-single-product-breadcrumbs {
     max-width: 1440px;
     margin: 0 auto;
-    padding: 20px 240px;
+    padding: 20px 30px;
 }
 
 .handy-single-product-breadcrumbs .handy-breadcrumb-nav {

--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.9.22
+ * Version:           1.9.23
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.9.22');
+define('HANDY_CUSTOM_VERSION', '1.9.23');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.9.23
+ * Version:           1.9.24
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.9.23');
+define('HANDY_CUSTOM_VERSION', '1.9.24');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.9.22';
+	const VERSION = '1.9.23';
 
 	/**
 	 * Single instance of the class

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.9.23';
+	const VERSION = '1.9.24';
 
 	/**
 	 * Single instance of the class

--- a/includes/products/class-products-renderer.php
+++ b/includes/products/class-products-renderer.php
@@ -26,14 +26,10 @@ class Handy_Custom_Products_Renderer {
 		
 		// Check for category parameter and handle subcategory logic
 		if ($display_mode === 'categories' && !empty($filters['category'])) {
-			// Try to get subcategories first
-			$categories = $this->get_filtered_categories($filters);
-			
-			// If no subcategories found, fall back to list mode
-			if (empty($categories)) {
-				$display_mode = 'list';
-				Handy_Custom_Logger::log("Falling back to list mode for category: {$filters['category']}", 'info');
-			}
+			// For specific category pages, we want to show individual products, not subcategories
+			// This ensures /products/appetizers/ shows product cards, not subcategory cards
+			$display_mode = 'list';
+			Handy_Custom_Logger::log("Forcing list mode for category archive: {$filters['category']}", 'info');
 		}
 
 		// Load the main archive template with appropriate data


### PR DESCRIPTION
## Summary
• Fix product archive pages (like `/products/appetizers/`) to show individual product cards instead of category cards
• Force list mode when viewing specific category archives to ensure correct display behavior
• Individual product cards now show single "See Product Details" button as intended

## Problem Fixed
Previously, `/products/appetizers/` was showing category cards with 2 action buttons because the "appetizers" category had subcategories, keeping the system in "categories" mode instead of falling back to "list" mode.

## Solution
Modified `includes/products/class-products-renderer.php` to force `display="list"` when a specific category parameter is provided, ensuring individual product cards are displayed regardless of subcategory structure.

## Expected Behavior
- **`/products/`**: Shows category cards with "See Options" or "See Products" buttons (2 buttons)
- **`/products/appetizers/`**: Shows individual product cards with "See Product Details" button (1 button)

## Test plan
- [ ] Verify `/products/appetizers/` shows individual product cards with single button
- [ ] Confirm product cards display "See Product Details" button
- [ ] Validate main `/products/` page still shows category cards correctly
- [ ] Test other category archive pages show product cards consistently

🤖 Generated with [Claude Code](https://claude.ai/code)