### PR TITLE
Fix primary category validation to prevent empty Yoast SEO data

### DIFF
--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.9.27
+ * Version:           1.9.28
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.9.27');
+define('HANDY_CUSTOM_VERSION', '1.9.28');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.9.27';
+	const VERSION = '1.9.28';
 
 	/**
 	 * Single instance of the class
@@ -639,9 +639,11 @@ class Handy_Custom {
 		if (function_exists('yoast_get_primary_term')) {
 			Handy_Custom_Logger::log("get_primary_category_with_fallbacks: Trying yoast_get_primary_term", 'debug');
 			$primary_category = yoast_get_primary_term('product-category', $post_id);
-			if ($primary_category) {
+			if ($primary_category && !empty($primary_category->slug) && !empty($primary_category->term_id)) {
 				Handy_Custom_Logger::log("Found primary category via yoast_get_primary_term: {$primary_category->name} (slug: {$primary_category->slug}, ID: {$primary_category->term_id})", 'debug');
 				return $primary_category;
+			} else if ($primary_category) {
+				Handy_Custom_Logger::log("get_primary_category_with_fallbacks: Yoast returned invalid primary category (empty slug or ID), falling back", 'warning');
 			}
 		}
 		


### PR DESCRIPTION
## Summary
- Fix primary category validation in `get_primary_category_with_fallbacks()` method to prevent double slashes in URLs
- Add validation to ensure primary category has valid slug and ID before using Yoast SEO data
- Add warning logging when Yoast returns invalid data and fallback is triggered

## Problem
The "Crab House Seafood Minis" product was generating malformed URLs with double slashes (`/products//appetizers/crab-house-seafood-minis/`) because Yoast SEO's `yoast_get_primary_term()` function was returning a category object with empty slug and ID values, which passed the basic `if ($primary_category)` check but failed during URL generation.

## Solution
Enhanced the validation in `get_primary_category_with_fallbacks()` to check not only that the primary category object exists, but also that it has valid `slug` and `term_id` properties. When Yoast returns invalid data, the system now properly falls back to the existing fallback methods.

## Changes
- Updated primary category validation logic in `includes/class-handy-custom.php:642`
- Added warning logging when invalid Yoast data is detected
- Updated version to 1.9.28

## Test Plan
- [ ] Test the "Crab House Seafood Minis" product URL generation
- [ ] Verify URLs no longer contain double slashes
- [ ] Confirm fallback logic works when Yoast data is invalid
- [ ] Test other products to ensure no regression

🤖 Generated with [Claude Code](https://claude.ai/code)