### PR TITLE
Fix breadcrumb hierarchical URLs to match URL structure

### DIFF
--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.9.28
+ * Version:           1.9.29
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.9.28');
+define('HANDY_CUSTOM_VERSION', '1.9.29');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/handy-custom.php
+++ b/handy-custom.php
@@ -34,7 +34,7 @@ define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 
 // LOGGING CONTROL - Set to true to enable logging
-define('HANDY_CUSTOM_DEBUG', true);
+define('HANDY_CUSTOM_DEBUG', false);
 
 // Load main plugin class
 require_once plugin_dir_path(__FILE__) . 'includes/class-handy-custom.php';

--- a/includes/class-handy-custom.php
+++ b/includes/class-handy-custom.php
@@ -14,7 +14,7 @@ class Handy_Custom {
 	/**
 	 * Plugin version
 	 */
-	const VERSION = '1.9.28';
+	const VERSION = '1.9.29';
 
 	/**
 	 * Single instance of the class


### PR DESCRIPTION
## Summary
- Fixed breadcrumb generation to use the same primary category detection logic as URL generation system
- Updated breadcrumb URL generation to use utility functions for consistent hierarchical URLs
- Removed unused `get_primary_product_category()` function
- Breadcrumbs now respect Yoast SEO primary category settings

## Problem Fixed
Previously, breadcrumbs and URL generation used different methods to determine primary categories:
- **URL Generation**: Used `get_primary_category_with_fallbacks()` with Yoast SEO integration
- **Breadcrumbs**: Used `get_primary_product_category()` with simple logic

This caused inconsistencies when products had multiple top-level categories with one marked as primary in Yoast SEO.

## Changes Made
- **`modify_yoast_breadcrumbs()`**: Updated to use `get_primary_category_with_fallbacks()` for primary category detection
- **URL Generation**: Now uses `Handy_Custom_Products_Utils::get_category_url()` and `get_subcategory_url()` for consistent hierarchical URLs
- **Code Cleanup**: Removed unused `get_primary_product_category()` function

## Expected Behavior
For product "Crab House Seafood Minis" in "Appetizers > Crab Cake Minis":
- **URL**: `/products/appetizers/crab-cake-minis/crab-house-seafood-minis/`
- **Breadcrumbs**: `Home / Products / Appetizers / Crab Cake Minis / Crab House Seafood Minis`

Where:
- "Appetizers" links to `/products/appetizers/`
- "Crab Cake Minis" links to `/products/appetizers/crab-cake-minis/`

## Test plan
- [x] Verify breadcrumbs show correct hierarchical structure for child categories
- [x] Verify breadcrumb URLs match actual URL structure
- [x] Ensure Yoast SEO primary category settings are respected
- [x] Test edge cases with multiple top-level categories

🤖 Generated with [Claude Code](https://claude.ai/code)