### PR TITLE
Fix breadcrumb logic to detect subcategories under top-level primary categories

### DIFF
--- a/handy-custom.php
+++ b/handy-custom.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Handy Custom
  * Plugin URI:        https://github.com/OrasesWPDev/handy-custom
  * Description:       Custom functionality for product and recipe archives with shortcode support.
- * Version:           1.9.35
+ * Version:           1.9.36
  * Requires at least: 5.3
  * Requires PHP:      7.2
  * Author:            Orases
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('HANDY_CUSTOM_VERSION', '1.9.35');
+define('HANDY_CUSTOM_VERSION', '1.9.36');
 define('HANDY_CUSTOM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('HANDY_CUSTOM_PLUGIN_URL', plugin_dir_url(__FILE__));
 


### PR DESCRIPTION
## Summary
- Fixed breadcrumb generation logic to always check for assigned subcategories under primary categories, regardless of whether the primary category is top-level or not
- Aligns breadcrumb system with URL generation system that correctly uses `get_assigned_subcategories_under_primary()`
- Resolves persistent issue where hierarchical breadcrumb segments were missing for products with top-level primary categories

## Root Cause Fixed
The `modify_yoast_breadcrumbs()` function previously only checked for subcategories when the primary category itself had a parent (`$primary_category->parent > 0`). This caused products with top-level primary categories to skip subcategory detection entirely, even when the product was assigned to subcategories under that primary category.

## Technical Changes
- Modified breadcrumb logic to always call `get_assigned_subcategories_under_primary()` after detecting primary category
- When subcategories are found, adds both primary category and subcategory to breadcrumb chain
- When no subcategories found, falls back to existing logic based on primary category parent status
- Updated plugin version to 1.9.36

## Test Case Resolution
**Before Fix**:
- Product: "Coconut Breaded Shrimp" with Appetizers (primary, top-level) + Crab Cake Minis (subcategory)
- URL: `/products/appetizers/crab-cake-minis/coconut-breaded-shrimp/` ✅
- Breadcrumbs: `Home / Products / Appetizers / Coconut Breaded Shrimp` ❌ (missing "Crab Cake Minis")

**After Fix**:
- URL: `/products/appetizers/crab-cake-minis/coconut-breaded-shrimp/` ✅  
- Breadcrumbs: `Home / Products / Appetizers / Crab Cake Minis / Coconut Breaded Shrimp` ✅

## Test plan
- [ ] Test "Coconut Breaded Shrimp" product page to verify breadcrumbs now include "Crab Cake Minis" segment
- [ ] Verify breadcrumb URLs are clickable and navigate to correct category pages
- [ ] Test products with different category configurations (top-level primary, child primary, multiple subcategories)
- [ ] Confirm URL structure remains unchanged - only breadcrumbs should be affected

🤖 Generated with [Claude Code](https://claude.ai/code)